### PR TITLE
Let's test this baby

### DIFF
--- a/healthd/healthd.cpp
+++ b/healthd/healthd.cpp
@@ -37,8 +37,15 @@
 using namespace android;
 
 // Periodic chores intervals in seconds
+#ifdef QCOM_HARDWARE
+#define DEFAULT_PERIODIC_CHORES_INTERVAL_FAST (60 * 10)
+//For the designs without low battery detection,need to enable
+//the default 60*10s wakeup timer to periodic check.
+#define DEFAULT_PERIODIC_CHORES_INTERVAL_SLOW -1
+#else
 #define DEFAULT_PERIODIC_CHORES_INTERVAL_FAST (60 * 1)
 #define DEFAULT_PERIODIC_CHORES_INTERVAL_SLOW (60 * 10)
+#endif
 
 static struct healthd_config healthd_config = {
     .periodic_chores_interval_fast = DEFAULT_PERIODIC_CHORES_INTERVAL_FAST,

--- a/healthd/healthd.cpp
+++ b/healthd/healthd.cpp
@@ -37,7 +37,7 @@
 using namespace android;
 
 // Periodic chores intervals in seconds
-#define DEFAULT_PERIODIC_CHORES_INTERVAL_FAST (60 * 10)
+#define DEFAULT_PERIODIC_CHORES_INTERVAL_FAST (60 * 1)
 #define DEFAULT_PERIODIC_CHORES_INTERVAL_SLOW (60 * 10)
 
 static struct healthd_config healthd_config = {


### PR DESCRIPTION
Somehow RTC wakeup timer is not disabled with cm-12.0.

Let's test this baby and follow cm-11.0.
