### PR TITLE
healthd: Define BCL and BMS to avoid logspam

### DIFF
--- a/healthd/BatteryMonitor.cpp
+++ b/healthd/BatteryMonitor.cpp
@@ -132,6 +132,8 @@ BatteryMonitor::PowerSupplyType BatteryMonitor::readPowerSupplyType(const String
     struct sysfsStringEnumMap supplyTypeMap[] = {
             { "Unknown", ANDROID_POWER_SUPPLY_TYPE_UNKNOWN },
             { "Battery", ANDROID_POWER_SUPPLY_TYPE_BATTERY },
+            { "BCL", ANDROID_POWER_SUPPLY_TYPE_BATTERY },
+            { "BMS", ANDROID_POWER_SUPPLY_TYPE_BATTERY },
             { "UPS", ANDROID_POWER_SUPPLY_TYPE_AC },
             { "Mains", ANDROID_POWER_SUPPLY_TYPE_AC },
             { "USB", ANDROID_POWER_SUPPLY_TYPE_USB },


### PR DESCRIPTION
- BCL and BMS are battery services.

Change-Id: I284fd2dea7cc5032f8e4ebbcfb227fd8fe25c8f9
Signed-off-by: Pranav Vashi neobuddy89@gmail.com
